### PR TITLE
Fix error not recognize the jmvOpn object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,5 +12,5 @@ Description: Reshape datasets from long to wide or from
 License: GPL
 Encoding: UTF-8
 LazyData: true
-Imports: jmvcore (>= 0.8.5), R6, jmvReadWrite
+Imports: jmvcore (>= 0.8.5), R6
 Remotes: sjentsch/jmvReadWrite,


### PR DESCRIPTION
this `:::` not allowed on CRAN.
so, this:
`jmvReadWrite:::jmvOpn(dtaFrm = data, dtaTtl = "Untitled")`
raises an error in `jReshape`, which in the `savedata()` function does not recognize the **`jmvOpn object`** (not exported by `jmvReadWrite`).