### PR TITLE
Fixed up

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,5 +12,6 @@ Description: Reshape datasets from long to wide or from
 License: GPL
 Encoding: UTF-8
 LazyData: true
-Imports: jmvcore (>= 0.8.5), R6, jmvReadWrite
+Imports: jmvcore (>= 0.8.5), R6
+Suggests: utils
 Remotes: sjentsch/jmvReadWrite,

--- a/R/savedata.R
+++ b/R/savedata.R
@@ -1,12 +1,17 @@
 savedata<-function(obj,data) {
-  
-    jmvReadWrite:::jmvOpn(dtaFrm = data, dtaTtl =  "Untitled")
-    
+
+  ## -- If jmvReadWrite is NOT imported by CRUN
+  jmvReadWrite:::jmvOpn(dtaFrm = data, dtaTtl =  "Untitled")
+
+  ## If jmvReadWrite is imported from CRUN uncomment the two lines
+  ## below and comment out the function call on the line above
+  #jmvOpn <- utils::getFromNamespace("jmvOpn", "jmvReadWrite")
+  #jmvOpn(dtaFrm = data, dtaTtl =  "Untitled")
 
 }
 
 showdata<-function(obj,data) {
-  
+
   nl<-50
   data$row<-1:dim(data)[1]
   nr<-nrow(data)

--- a/jamovi/0000.yaml
+++ b/jamovi/0000.yaml
@@ -24,11 +24,11 @@ analyses:
     ns: jReshape
     menuGroup: Data
     menuTitle: Long to wide
-  - title: Merge
-    name: merge
-    ns: jReshape
-    menuGroup: Data
-    menuTitle: Merge
+  # - title: Merge
+  #   name: merge
+  #   ns: jReshape
+  #   menuGroup: Data
+  #   menuTitle: Merge
 usesNative: true
 minApp: 2.4.2
 

--- a/temp/.Rbuildignore
+++ b/temp/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$


### PR DESCRIPTION
**`:::`** not allowed on **CRAN**.
so, this:
`jmvReadWrite:::jmvOpn(dtaFrm = data, dtaTtl = "Untitled")`
raises an **error** in `jReshape`, which in the `savedata()` function does not recognize the `jmvOpn()` [**error**: object not found] function not exported by `jmvReadWrite`.